### PR TITLE
Bump to postgres 9.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM postgres:9.3
+FROM postgres:9.4.1
 MAINTAINER Powell Kinney <powell@vin.li>
 
 RUN apt-get update \
-    && apt-get -y install postgresql-contrib-9.3 postgresql-9.3-postgis-2.1 postgis \
+    && apt-get -y install postgresql-contrib-9.4 postgresql-9.4-postgis-2.1 postgis \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Production postgres is running 9.4. The version bump isn't huge, but there is the possibility
of issues popping up. Rather than finding out about them on dev or prod, let's catch them 
on a developers machine.  Additionally, AWS will bump us minor versions, so you can see in
this branches `Dockerfile`, I am extending postgres 9.4.1, as that is our current
production version. 
- This image is ~25 MB or so smaller than the other one
- We should handle version increments via git/docker tags.
  That being said, I think it makes sense that this repo be renamed to simply postgres-gis.
- I tagged the previous commit on this repo to 9.3

So going forward, I think the following should happen:
- Create a new dockerhub project for `postgres-gis` & build/push this image to it.
- Move projects over one by one
- Keep on winning.

Thanks!
