### PR TITLE
Lock contrib package to a compatible version.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,5 +2,5 @@ FROM postgres:9.5.2
 MAINTAINER Powell Kinney <powell@vin.li>
 
 RUN apt-get update \
-    && apt-get -y install postgresql-contrib-9.5 postgresql-9.5-postgis-2.2 postgis \
+    && apt-get -y install postgresql-contrib-9.5=9.5.2-1.pgdg80+1 postgresql-9.5-postgis-2.2 postgis \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
This locks  the `postgresql-contrib-9.5` package to a version that's compatible with postgres 9.5.2.
